### PR TITLE
Implement polly as a container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,8 +34,8 @@ services:
     networks:
       - monitoring
     environment: 
-      - HPWC_IP=192.168.86.23
-      - INFLUX_IP=host.docker.internal
+      - HPWC_IP
+      - INFLUX_IP
 networks:
   monitoring:
 volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.7"
 services:
   grafana:
     image: grafana/grafana
@@ -26,7 +26,16 @@ services:
       - INFLUXDB_ADMIN_ENABLED=true
 
       - INFLUXDB_ADMIN_USER=admin
-      - INFLUXDB_ADMIN_PASSWORD=admin 
+      - INFLUXDB_ADMIN_PASSWORD=admin
+  polly:
+    image: averysmalldog/tesla-gen3wc-monitor
+    container_name: polly
+    restart: always
+    networks:
+      - monitoring
+    environment: 
+      - HPWC_IP=192.168.86.23
+      - INFLUX_IP=host.docker.internal
 networks:
   monitoring:
 volumes:

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.15.6 AS builder
+WORKDIR /go/src/github.com/averysmalldog/tesla-gen3wc-monitor/
+RUN go get -d -v github.com/averysmalldog/polly  
+COPY main.go .
+RUN GOOS=linux go build -o app .
+
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/averysmalldog/tesla-gen3wc-monitor/app .
+CMD ["./app"]

--- a/dockerfile
+++ b/dockerfile
@@ -1,11 +1,9 @@
 FROM golang:1.15.6 AS builder
 WORKDIR /go/src/github.com/averysmalldog/tesla-gen3wc-monitor/
-RUN go get -d -v github.com/averysmalldog/polly  
+RUN go get -d -v github.com/averysmalldog/polly 
 COPY main.go .
-RUN GOOS=linux go build -o app .
+RUN GOOS=linux CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o app .
 
-FROM alpine:latest  
-RUN apk --no-cache add ca-certificates
-WORKDIR /root/
+FROM scratch
 COPY --from=builder /go/src/github.com/averysmalldog/tesla-gen3wc-monitor/app .
-CMD ["./app"]
+ENTRYPOINT [ "/app" ]


### PR DESCRIPTION
By turning `polly` into a container, the project is decoupled. This PR establishes the foundation to later rip all the `polly` components out and leave us with a license, a readme, a dockerfile, and a sample dashboard.